### PR TITLE
Added callback to table population to set appropriate column width.

### DIFF
--- a/src/component/assessing/report.jsx
+++ b/src/component/assessing/report.jsx
@@ -90,11 +90,6 @@ class ReportBase extends React.Component {
   getColumn(){
     return[
       {
-        headerName: "Category", 
-        field : "category",
-        resizable : true
-      },
-      {
         headerName: "Feature", 
         field : "feature"     ,
         resizable : true


### PR DESCRIPTION
Report table now fits screen when the automatic width is too small.
closes #77 